### PR TITLE
tool_operate: do not set CURLOPT_QUICK_EXIT in debug builds

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -581,7 +581,7 @@ static void destroy_async_data(struct Curl_async *async)
      * before the FD is invalidated to avoid EBADF on EPOLL_CTL_DEL
      */
     Curl_multi_closed(data, sock_rd);
-    sclose(sock_rd);
+    wakeup_close(sock_rd);
 #endif
   }
   async->tdata = NULL;

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -266,7 +266,7 @@ static CURLcode ntlm_wb_response(struct Curl_easy *data, struct ntlmdata *ntlm,
   size_t len_in = strlen(input), len_out = 0;
   struct dynbuf b;
   char *ptr = NULL;
-  usigned char buf[1024]
+  unsigned char buf[1024];
   Curl_dyn_init(&b, MAX_NTLM_WB_RESPONSE);
 
   while(len_in > 0) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1274,6 +1274,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(result && (use_proto == proto_ipfs || use_proto == proto_ipns))
           break;
 
+#ifndef DEBUGBUILD
         /* On most modern OSes, exiting works thoroughly,
            we'll clean everything up via exit(), so don't bother with
            slow cleanups. Crappy ones might need to skip this.
@@ -1282,6 +1283,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         result = curl_easy_setopt(curl, CURLOPT_QUICK_EXIT, 1L);
         if(result)
           break;
+#endif
 
         if(!config->tcp_nodelay)
           my_setopt(curl, CURLOPT_TCP_NODELAY, 0L);


### PR DESCRIPTION
Since it allows (small) memory leaks that interfere with torture tests and regular memory-leak checks.

Reported-by: Dan Fandrich
Fixes #12834
Closes #12835